### PR TITLE
Check consistency proof

### DIFF
--- a/new-prisons.py
+++ b/new-prisons.py
@@ -144,8 +144,6 @@ rsf_req.encoding = 'utf-8'
 
 for line in rsf_req.iter_lines():
     [command, *args] = line.rstrip().split(b'\t')
-    print(command)
-    print(args)
     proc.process(command,args)
 
 proc.resolve_records()


### PR DESCRIPTION
This (very scrappy) code checks the consistency proof of the prison
register when fetching updates.  If the consistency proof fails, we
assume the data has been deleted and restarted, so we start again from
the beginning.

We don't actually check that the entries match the root hash, so a
register could still lie to us by sending entries in the RSF that
don't match the root hash.  This code defends against Murphy, but not
Macchiavelli.